### PR TITLE
Fix notifyIcon text not being set correctly when it is less than 63 characters

### DIFF
--- a/Magpie-0.9.1/Magpie/MainWindow.xaml.cs
+++ b/Magpie-0.9.1/Magpie/MainWindow.xaml.cs
@@ -362,7 +362,7 @@ namespace Magpie {
 					Settings.Default.Hotkey,
 					cbbScaleMode.SelectedItem?.ToString(),
 					((ComboBoxItem)cbbCaptureMethod.SelectedItem)?.Content.ToString()
-				).Substring(0, 63); // .NET versions before .NET 6 only support a maximum of 63 characters here.
+				).Take(63).ToString(); // .NET versions before .NET 6 only support a maximum of 63 characters here.
 
 				Hide();
 				notifyIcon.Visible = true;


### PR DESCRIPTION
Fixes bug introduced in f7b8d61835419a4cdd7812fc340eb55d9f402690