### PR TITLE
Fix notifyIcon text not showing correctly

### DIFF
--- a/Magpie-0.9.1/Magpie/MainWindow.xaml.cs
+++ b/Magpie-0.9.1/Magpie/MainWindow.xaml.cs
@@ -357,12 +357,14 @@ namespace Magpie {
 		private void Window_StateChanged(object sender, EventArgs e) {
 			if (WindowState == WindowState.Minimized) {
 				// 更新文字提示
-				notifyIcon.Text = string.Format(
+				string text = string.Format(
 					Properties.Resources.UI_SysTray_Text,
 					Settings.Default.Hotkey,
 					cbbScaleMode.SelectedItem?.ToString(),
 					((ComboBoxItem)cbbCaptureMethod.SelectedItem)?.Content.ToString()
-				).Take(63).ToString(); // .NET versions before .NET 6 only support a maximum of 63 characters here.
+				);
+				// .NET versions before .NET 6 only support a maximum of 63 characters here.
+				notifyIcon.Text = text.Substring(0, Math.Min(text.Length, 63)); 
 
 				Hide();
 				notifyIcon.Visible = true;


### PR DESCRIPTION

![2023-04-10_15-24-52](https://user-images.githubusercontent.com/78761720/230901925-77a4beca-8aca-40ab-aecf-d8e170e7efb7.png)

I'm _really_ sorry to bother you like this, but it appears that I've made another mistake...
